### PR TITLE
Added fix for JSON package parsing

### DIFF
--- a/tools/upip.py
+++ b/tools/upip.py
@@ -182,8 +182,11 @@ def install_pkg(pkg_spec, install_path):
     packages = data["releases"][latest_ver]
     del data
     gc.collect()
-    assert len(packages) == 1
-    package_url = packages[0]["url"]
+    idx = -1
+    for i in range(len(packages)):
+        if packages[i]["python_version"] == "source":
+            idx = i
+    package_url = packages[idx]["url"]
     print("Installing %s %s from %s" % (pkg_spec, latest_ver, package_url))
     package_fname = op_basename(package_url)
     f1 = url_open(package_url)
@@ -195,6 +198,7 @@ def install_pkg(pkg_spec, install_path):
         f1.close()
     del f3
     del f2
+    del idx
     gc.collect()
     return meta
 


### PR DESCRIPTION
The original design of upip did not handle packages that could have either combination of wheels/tar.gz files as entries. This would often break a package install. This is corrected by checking the JSON data for which link has "source" as its "python_version". The resulting index would then be used to pull the correct file. Not sure if we need code to check the value of "idx" (might not be appropriate for embedded systems). I've tested this change, but please test further before committing to master (or whichever branch is most appropriate).